### PR TITLE
fix(bus): fixed #32 and refactor bus models

### DIFF
--- a/src/api/models/buses.py
+++ b/src/api/models/buses.py
@@ -306,26 +306,26 @@ class Buses:
     ) -> Route:
         # 這裡不用 match 的原因是因為資料中有些會多空格
         # 下山
-        if dep_stop.count("台積") > 0:
-            if line.count("red") > 0 and from_gen_2:
+        if "台積" in dep_stop:
+            if "red" in line and from_gen_2:
                 return red_M5_M2
-            elif line.count("red") > 0 and not from_gen_2:
+            elif "red" in line and not from_gen_2:
                 return red_M5_M1
-            elif line.count("green") > 0 and from_gen_2:
+            elif "green" in line and from_gen_2:
                 return green_M5_M2
-            elif line.count("green") > 0 and not from_gen_2:
+            elif "green" in line and not from_gen_2:
                 return green_M5_M1
             else:
                 print(dep_stop, line)
         # 上山
         else:
-            if dep_stop.count("校門") > 0 and line.count("red") > 0:
+            if "校門" in dep_stop and "red" in line:
                 return red_M1_M5
-            elif dep_stop.count("綜二") > 0 and line.count("red") > 0:
+            elif "綜二" in dep_stop and "red" in line:
                 return red_M2_M5
-            elif dep_stop.count("校門") > 0 and line.count("green") > 0:
+            elif "校門" in dep_stop and "green" in line:
                 return green_M1_M5
-            elif dep_stop.count("綜二") > 0 and line.count("green") > 0:
+            elif "綜二" in dep_stop and "green" in line:
                 return green_M2_M5
             else:
                 print(dep_stop, line)

--- a/src/api/schemas/buses.py
+++ b/src/api/schemas/buses.py
@@ -90,7 +90,7 @@ class BusMainSchedule(BaseModel):
 
 
 class BusStopsQueryResult(BaseModel):
-    bus_info: BusNandaSchedule | BusMainSchedule = Field(..., description="公車資訊")
+    bus_info: BusMainSchedule | BusNandaSchedule = Field(..., description="公車資訊")
     arrive_time: str = Field(..., description="預計到達時間")
 
 


### PR DESCRIPTION
- #32 的原因是因為在
``` python
# src/api/schemas/buses.py
bus_info: BusNandaSchedule | BusMainSchedule = Field(..., description="公車資訊")
```
中，`BusNandaSchedule` 是 `BusMainSchedule` 子集合，所以 `|` 判斷會先抓前面那一個，導致 `depStop` 和 `line` 消失。